### PR TITLE
Fix raw string not being raw

### DIFF
--- a/yamltotm.py
+++ b/yamltotm.py
@@ -119,7 +119,7 @@ def str_constructor(loader, data):
 
 
 def subst_string(line):
-    return re.sub('\$(\$|\w+)', dictrepl, line)
+    return re.sub(r'\$(\$|\w+)', dictrepl, line)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes the following warning:

SyntaxWarning: invalid escape sequence '\$'
  return re.sub('\$(\$|\w+)', dictrepl, line)